### PR TITLE
Remove compile files from src folder

### DIFF
--- a/src/compile.sh
+++ b/src/compile.sh
@@ -1,1 +1,0 @@
-make all PETSC_DIR=/Users/victorsacek/Documents/petsc PETSC_ARCH=arch-label-debug

--- a/src/compile_opt.sh
+++ b/src/compile_opt.sh
@@ -1,1 +1,0 @@
-make all PETSC_DIR=/Users/victorsacek/Documents/petsc PETSC_ARCH=arch-label-optimized


### PR DESCRIPTION
Remove src/compile.sh and src/compile_opt.sh because they are not necessary to compile Mandyoc 

Fix #19 