### PR TITLE
WIP - add docker image

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,91 @@
+# NOTE: Pin actions to a specific commit to avoid having the authentication
+# token stolen if the Action is compromised. See the comments and links here:
+# https://github.com/pypa/gh-action-pypi-publish/issues/27
+#
+
+name: build-docker-image
+
+# Only build the master branch and releases.
+on:
+  push:
+    branches:
+      - "main"
+
+    tags:
+      - "v*.*.*"
+
+jobs:
+  # Build the docker image
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Cancel any previous run of the test job
+      # We pin the commit hash corresponding to v0.5.0, and not pinning the tag
+      # because we are giving full access through the github.token.
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@148d9a848c6acaf90a3ec30bc5062f646f8a4163
+        with:
+          access_token: ${{ github.token }}
+
+      # Cache layer
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      # Checks-out your repository under $GITHUB_WORKSPACE
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # Need to fetch more than the last commit so that setuptools-scm can
+          # create the correct version string. If the number of commits since
+          # the last release is greater than this, the version still be wrong.
+          # Increase if necessary.
+          fetch-depth: 100
+          # The GitHub token is preserved by default but this job doesn't need
+          # to be able to push to GitHub.
+          persist-credentials: false
+
+      - name: Docker meta
+        id: meta
+        uses: crazy-max/ghaction-docker-meta@v2
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            rafaelmds/mandyoc
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker
+          file: mandyoc.Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/docker/deps.Dockerfile
+++ b/docker/deps.Dockerfile
@@ -1,0 +1,67 @@
+# =============================================================================
+# MANDYOC Dependencies Docker Image
+# =============================================================================
+#
+# Builds the base Docker image with dependencies for MANDYOC.
+# MANDYOC is hosted at https://github.com/ggciag/mandyoc.
+#
+
+FROM debian:10 AS base_stage
+
+LABEL maintainer "Rafael Silva <rafael.m.silva@alumni.usp.br>"
+
+# =============================================================================
+# Variables
+# =============================================================================
+ENV PETSC_VERSION 3.15.0
+ENV PETSC_DIR /home/petsc-${PETSC_VERSION}
+ENV PETSC_ARCH optimized-${PETSC_VERSION}
+
+# =============================================================================
+# Install dependencies
+# =============================================================================
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        gcc \
+        gfortran \
+        python \
+        vim \
+        nano \
+        git \
+        curl \
+        rsync \
+        ca-certificates \
+        bash-completion \
+        openssh-client \
+        openssh-server && \
+    apt-get clean && \
+    apt-get autoremove; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    update-ca-certificates
+
+# =============================================================================
+# Building and installing PETSc
+# =============================================================================
+FROM base_stage AS petsc_stage
+
+RUN curl -k https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-${PETSC_VERSION}.tar.gz \
+        | tar xzvf - -C $(dirname ${PETSC_DIR}) && \
+    cd ${PETSC_DIR} && \
+    ./configure PETSC_DIR=${PETSC_DIR} PETSC_ARCH=${PETSC_ARCH} \
+        --with-debugging=0 \
+        COPTFLAGS="-O3 -march=native -mtune=native" \
+        CXXOPTFLAGS="-O3 -march=native -mtune=native" \
+        FOPTFLAGS="-O3 -march=native -mtune=native" \
+        --with-cc=gcc \
+        --with-cxx=g++ \
+        --with-fc=gfortran \
+        --download-fblaslapack \
+        --download-mpich \
+        --download-superlu_dist \
+        --download-metis \
+        --download-parmetis \
+        --download-mumps \
+        --download-scalapack \
+        --download-hdf5 && \
+    make PETSC_DIR=${PETSC_DIR} PETSC_ARCH=${PETSC_ARCH} all

--- a/docker/mandyoc.Dockerfile
+++ b/docker/mandyoc.Dockerfile
@@ -13,21 +13,18 @@ LABEL maintainer "Rafael Silva <rafael.m.silva@alumni.usp.br>"
 # =============================================================================
 # Variables
 # =============================================================================
-ENV PETSC_VERSION 3.15.0
-ENV PETSC_DIR /home/petsc-${PETSC_VERSION}
-ENV PETSC_ARCH optimized-${PETSC_VERSION}
-ENV MANDYOC_DIR /home/mandyoc
-ENV WORKDIR /home/simulation
+ENV MANDYOC_DIR /home/${USER}/mandyoc
 
 # =============================================================================
 # Building MANDYOC
 # =============================================================================
-RUN git clone https://github.com/ggciag/mandyoc ${MANDYOC_DIR} && \
-    cd ${MANDYOC_DIR} && \
-    make all && \
-    cp mandyoc /usr/local/bin
+RUN git clone https://github.com/ggciag/mandyoc ${MANDYOC_DIR} \
+    && cd ${MANDYOC_DIR} \
+    && make all
 
 # =============================================================================
 # Final setup
 # =============================================================================
-WORKDIR /simulation
+USER ${USER}
+
+WORKDIR /home/${USER}/simulation

--- a/docker/mandyoc.Dockerfile
+++ b/docker/mandyoc.Dockerfile
@@ -1,0 +1,33 @@
+# =============================================================================
+# MANDYOC Docker Image
+# =============================================================================
+#
+# Builds a Docker image for geodynamics modelling software MANDYOC.
+# MANDYOC is hosted at https://github.com/ggciag/mandyoc.
+#
+
+FROM rafaelmds/mandyoc-dependencies:latest AS mandyoc_stage
+
+LABEL maintainer "Rafael Silva <rafael.m.silva@alumni.usp.br>"
+
+# =============================================================================
+# Variables
+# =============================================================================
+ENV PETSC_VERSION 3.15.0
+ENV PETSC_DIR /home/petsc-${PETSC_VERSION}
+ENV PETSC_ARCH optimized-${PETSC_VERSION}
+ENV MANDYOC_DIR /home/mandyoc
+ENV WORKDIR /home/simulation
+
+# =============================================================================
+# Building MANDYOC
+# =============================================================================
+RUN git clone https://github.com/ggciag/mandyoc ${MANDYOC_DIR} && \
+    cd ${MANDYOC_DIR} && \
+    make all && \
+    cp mandyoc /usr/local/bin
+
+# =============================================================================
+# Final setup
+# =============================================================================
+WORKDIR /simulation

--- a/docker/mandyoc.Dockerfile
+++ b/docker/mandyoc.Dockerfile
@@ -27,4 +27,6 @@ RUN git clone https://github.com/ggciag/mandyoc ${MANDYOC_DIR} \
 # =============================================================================
 USER ${USER}
 
+RUN mkdir /home/${USER}/simulation
+
 WORKDIR /home/${USER}/simulation


### PR DESCRIPTION
Fixes #24 

I tested on my fork and build works fine. After cache, it's consuming ~1 min build time.

Image for mandyoc depends on a base image with dependencies installed (mainly petsc). I've setup that separately and the build for this base dependency image it's not included in the gh action (to save build time).
Because it will not change so often, I think its fine to build and upload it manually for now.

We need to setup tokens if we going to merge this here. I think only @victorsacek have access to that.
We can use my personal token by now, but would be nice to have a dockerhub account for ggciag so that we don't have to use anyone personal token.

@victorsacek  @aguspesce @jamisonassuncao 