### PR TITLE
Rename the output file called sp_surface_global

### DIFF
--- a/src/sp.cpp
+++ b/src/sp.cpp
@@ -497,7 +497,7 @@ PetscErrorCode sp_write_surface_vec(PetscInt i)
 
 	MPI_Comm_rank(PETSC_COMM_WORLD, &rank);
 
-    sprintf(filename, "sp_surface_global_%010d.txt", i); CHKERRQ(ierr);
+    sprintf(filename, "sp_surface_global_%d.txt", i); CHKERRQ(ierr);
     ierr = PetscViewerASCIIOpen(PETSC_COMM_WORLD, filename, &viewer); CHKERRQ(ierr);
     ierr = VecView(sp_surface_global, viewer); CHKERRQ(ierr);
     ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);


### PR DESCRIPTION
I only eliminate the number of zeros before the dot in the name. 

I want to add the option to save this outputs in binary, but I'm not sure if I can do it 
If you accept this change (@rafaelmds, @victorsacek ), please merge this PR before merge the PR number #27 
