### PR TITLE
Improve Makefile changing the MPI variable for the test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,7 @@ Attach as much as possible of the following information to your issue:
 - a minimal parameter file that reproduces the issue,
 - the log.txt file that was created during the model run,
 - the error message you saw on your screen,
-- any information that helps us understand why you think this is a bug, and
-  how to reproduce it.
+- any information that helps us understand why you think this is a bug, and how to reproduce it.
 
 ## Making MANDYOC Better
 
@@ -75,6 +74,7 @@ General guidelines for pull requests (PRs):
 
   git commit
   ```
+
   After that **push up your changes** to your fork:
 
   ```bash
@@ -85,12 +85,11 @@ General guidelines for pull requests (PRs):
   Ensure the PR description clearly describes the problem and solution.
   Include the relevant issue number.
 
-**Remember to test your changes**. We have a regression test to check that the 
-Mandyoc output result for the Crameri model is equal to the expected result.
+**Remember to test your changes**. We have a regression test to check that the Mandyoc output result for the Crameri model is equal to the expected result.
 To make this test you need to install `pytest` and run:
 
 ```bash
-make test
+make test_mandyoc
 ```
 
 ## Do you have questions about MANDYOC code?

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SOURCEC = $(SRC)/main.cpp \
 	$(SRC)/sp.cpp
 OBJECTS = $(SOURCEC:%.cpp=%.o)
 
-MPI_PATH = ${PETSC_DIR}/${PETSC_ARCH}/bin
+MPIEXEC = ${PETSC_DIR}/${PETSC_ARCH}/bin/mpirun
 
 help:
 	@echo ""
@@ -40,8 +40,8 @@ help:
 test_mandyoc:
 
 	@echo "Run MANDYOC test may take several minutes.."
-	cd test/testing_data/ ; ${MPI_PATH}/mpirun -n 2 ../../mandyoc
-	pytest -v test/testing_result.py 
+	cd test/testing_data/ ; ${MPIEXEC} -n 2 ../../mandyoc
+	pytest -v test/testing_result.py
 
 # Build Mandyoc
 all: ${OBJECTS} chkopts

--- a/test/testing_result.py
+++ b/test/testing_result.py
@@ -1,5 +1,5 @@
 """
-Compare the Mandyoc output data with the expected data using the Crameri model 
+Compare the Mandyoc output data with the expected data using the Crameri model
 """
 import os
 import pytest


### PR DESCRIPTION
I used the reviewer recommendation and change MPI_PATH for MPIEXEC for the test option. 

```
-MPI_PATH = ${PETSC_DIR}/${PETSC_ARCH}/bin
+MPI_PATH = ${PETSC_DIR}/${PETSC_ARCH}/bin/mpirun

 test_mandyoc:
 
 	@echo "Run MANDYOC test may take several minutes.."
-	cd test/testing_data/ ; ${MPI_PATH}/mpirun -n 2 ../../mandyoc
+	cd test/testing_data/ ; ${MPIEXEC} -n 2 ../../mandyoc
 	pytest -v test/testing_result.py
```

[https://github.com/openjournals/joss-reviews/issues/3551](https://github.com/openjournals/joss-reviews/issues/3551)