### PR TITLE
fix MPIEXEC in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,6 @@ SOURCEC = $(SRC)/main.cpp \
 	$(SRC)/sp.cpp
 OBJECTS = $(SOURCEC:%.cpp=%.o)
 
-MPIEXEC = ${PETSC_DIR}/${PETSC_ARCH}/bin/mpirun
-
 help:
 	@echo ""
 	@echo "Commands:"
@@ -38,7 +36,6 @@ help:
 
 # Run test
 test_mandyoc:
-
 	@echo "Run MANDYOC test may take several minutes.."
 	cd test/testing_data/ ; ${MPIEXEC} -n 2 ../../mandyoc
 	pytest -v test/testing_result.py


### PR DESCRIPTION
This remove the definition of MPIEXEC added by #39.

It' not the best option to define MPIEXEC explicitly otherwise make would not utilize system's MPI.

Fix #42 