### PR TITLE
Remove default petsc path in the Makefile and istallation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,11 @@
 mandyoc
 test/__pycache__/
 
-# Ignore _build folder
-_build
 # Ignore the documentation building folder
 docs/_build
 
-# Ignore output when run the test 
-test/testing_data/density_* 
+# Ignore output when run the test
+test/testing_data/density_*
 test/testing_data/heat_*
 test/testing_data/pressure_*
 test/testing_data/strain_*
@@ -33,3 +31,5 @@ examples/*/interfaces.txt
 examples/continental_rift/*.png
 examples/Crameri2012_case2/interfaces.png
 
+# Ignore build files:
+src/*.o

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,10 +89,10 @@ General guidelines for pull requests (PRs):
 To make this test you need to install `pytest` and run:
 
 ```bash
-make test_mandyoc
+make test
 ```
 
-*NOTE*: you might need to manually set the `MPIREXEC` in the Makefile.
+_NOTE_: you might need to manually set the `MPIREXEC` in the Makefile.
 
 ## Do you have questions about MANDYOC code?
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ help:
 	@echo ""
 	@echo "  all		Build Mandyoc"
 	@echo "  install	Install MANDYOC in ~/.local/bin/"
-	@echo "  test		Run the MANDYOC test using 1 cores. It takes several munutes"
+	@echo "  test		Run the MANDYOC tests using 1 core. It takes several minutes."
 	@echo "  clear		Removes the files produced when building MANDYOC"
 	@echo ""
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,3 @@
-# Define PETSC_DIR to ~/petsc if it's not defined
-ifdef PETSC_DIR
-else
-PETSC_DIR = $(HOME)/petsc
-endif
-
 include ${PETSC_DIR}/lib/petsc/conf/variables
 include ${PETSC_DIR}/lib/petsc/conf/rules
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ BIN_DIR = bin
 MANDYOC = $(BIN_DIR)/mandyoc
 LOCAL_BIN = $(HOME)/.local/bin
 
-.PHONY: help all insatall clear test
+.PHONY: help all install clear test
 
 help:
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ SOURCEC = $(SRC)/main.cpp \
 OBJECTS = $(SOURCEC:%.cpp=%.o)
 PREFIX = $(HOME)/.local
 BINDIR = $(PREFIX)/bin
-BUILDDIR = bin
+INSTALL_PATH = bin
 MANDYOC = $(BUILDDIR)/mandyoc
 
 
@@ -44,7 +44,7 @@ help:
 all: $(MANDYOC)
 
 install: $(MANDYOC)
-	install $< $(BINDIR)/mandyoc
+	install $< $(INSTALL_PATH)/mandyoc
 
 test:
 	@echo "Run MANDYOC test may take several minutes..."

--- a/Makefile
+++ b/Makefile
@@ -25,25 +25,44 @@ SOURCEC = $(SRC)/main.cpp \
 	$(SRC)/veloc_total.cpp \
 	$(SRC)/sp.cpp
 OBJECTS = $(SOURCEC:%.cpp=%.o)
+BIN_DIR = bin
+MANDYOC = $(BIN_DIR)/mandyoc
+LOCAL_BIN = $(HOME)/.local/bin
+
+.PHONY: help all insatall clear test
 
 help:
 	@echo ""
 	@echo "Commands:"
 	@echo ""
-	@echo "  all		Build and install Mandyoc by running"
-	@echo "  test_mandyoc	Run the Mandyoc test using 2 cores. It takes several munutes"
+	@echo "  all		Build Mandyoc"
+	@echo "  install	Install MANDYOC in ~/.local/bin/"
+	@echo "  test		Run the MANDYOC test using 1 cores. It takes several munutes"
+	@echo "  clear		Removes the files produced when building MANDYOC"
 	@echo ""
 
-# Run test
-test_mandyoc:
-	@echo "Run MANDYOC test may take several minutes.."
-	cd test/testing_data/ ; ${MPIEXEC} -n 2 ../../mandyoc
+all: $(MANDYOC)
+	@echo ""
+	@echo "Mandyoc built in bin/"
+
+install: $(MANDYOC)
+	@echo ""
+	install $< $(LOCAL_BIN)
+
+test:
+	@echo "Run MANDYOC test may take several minutes..."
+	cd test/testing_data/ ; mpirun -n 1 mandyoc
 	pytest -v test/testing_result.py
 
-# Build Mandyoc
-all: ${OBJECTS} chkopts
-	-${CLINKER} -o mandyoc ${OBJECTS} ${PETSC_LIB}
+clear:
 	rm $(SRC)/*.o
+	rm -rf $(BIN_DIR)
 
 %.o: %.cpp
 	${PCC} -Wall -fdiagnostics-color -c $< -o $@ ${INCFLAGS}
+
+$(BIN_DIR):
+	mkdir $@
+
+$(MANDYOC): ${OBJECTS} | $(BIN_DIR)
+	-${CLINKER} -o $@ ${OBJECTS} ${PETSC_LIB}

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ help:
 
 all: $(MANDYOC)
 
-install: $(MANDYOC) | $(BINDIR)
+install: $(MANDYOC)
 	install $< $(BINDIR)/mandyoc
 
 test:

--- a/docs/files/installation.rst
+++ b/docs/files/installation.rst
@@ -28,20 +28,20 @@ PETSc Installation
 
 *Mandyoc* requires the `PETSc`_ library to run.
 The first step is to **download** the latest release of PETSc from `PETSc website`_
-or **clone** the repository into your machine::
+or **clone** the repository into your machine.
 
+Choose the path to your PETSC installation and clone the repository::
+
+	cd /path/to/petsc
 	git clone -b release https://gitlab.com/petsc/petsc.git $HOME/petsc
 
-By default, we will download/clone in ``~/petsc``.
-
 Second, **configure the PETSc build** and set up the installation directory.
-By default, we will install PETSc in ``~/petsc``.
 
 .. code-block:: bash
 
-	cd $HOME/petsc
+	cd path/to/petsc
 	./configure \
-	  PETSC_DIR=$HOME/petsc \
+	  PETSC_DIR=/path/to/petsc \
 	  PETSC_ARCH=arch-label-optimized \
 	  --with-debugging=0 \
 	  --with-cc=gcc \
@@ -82,19 +82,30 @@ Or follow the instructions that pop up on the terminal.
 
 For further information about the PETSc library, check the `PETSc website`_.
 
+Finally, *add a symlinks* of `mpirun` to `~/.local/bin`
+
+.. code-block::
+
+	ln -s /path/to/pets/arch-label-optimized/bin/mpirun ~/.local/bin/mpirun
+
+
 *Mandyoc* Installation
 ----------------------
 
-To install the *Mandyoc* in your machine,  you need to **clone or download  the latest release** of the
-code from the `Mandyoc repository page`_.
-
+To install the *Mandyoc* in your machine, you need to **clone or download the latest release** of the code from the `Mandyoc repository page`_.
 To clone the repository, navigate to the directory you wish to install *Mandyoc* and type:
 
 .. code-block:: bash
 
    git clone https://github.com/ggciag/mandyoc
 
-Next, **build and install** *Mandyoc* by running::
+Before to install Mandyoc, you mast *set an env variable* which indicates the path to PETSc installation folder:
+
+.. code-block:: bash
+
+	export PETSC_DIR=/path/to/petsc
+
+Next, *build and install Mandyoc* by running::
 
 	make all
 
@@ -107,11 +118,7 @@ Next, **build and install** *Mandyoc* by running::
 
 .. code-block::
 
-	make test_mandyoc
-
-.. note::
-
-	If you have any errors with the `MPIEXEC` variable, you must set it manually in the Makefile.
+	make test
 
 Examples
 --------

--- a/docs/files/installation.rst
+++ b/docs/files/installation.rst
@@ -118,6 +118,8 @@ Next, *install Mandyoc* in `~/.local/bin` with:
 	make install
 
 .. note::
+	Make sure the direrectory `~/.local/bin` exists, otherwise the command will fail.
+.. note::
 
 	To print *Mandyoc* runtime options, run mandyoc with `-flags` command line
 	argument.

--- a/docs/files/installation.rst
+++ b/docs/files/installation.rst
@@ -111,14 +111,23 @@ Before to install Mandyoc, you mast *set an env variable* which indicates the pa
 
 	make all
 
-Next, *install Mandyoc* in `~/.local/bin` with:
+Next, *install Mandyoc* with:
 
 .. code-block::
 
 	make install
 
+By default, it will be installed in `~/.local/bin`.
+
 .. note::
-	Make sure the direrectory `~/.local/bin` exists, otherwise the command will fail.
+
+	Make sure the directory `~/.local/bin` exists, otherwise the command will fail.
+	You can set the installation location by running:
+
+	.. code-block::
+
+		make INSTALL_PATH=~/install_path install
+
 .. note::
 
 	To print *Mandyoc* runtime options, run mandyoc with `-flags` command line

--- a/docs/files/installation.rst
+++ b/docs/files/installation.rst
@@ -105,9 +105,17 @@ Before to install Mandyoc, you mast *set an env variable* which indicates the pa
 
 	export PETSC_DIR=/path/to/petsc
 
-Next, *build and install Mandyoc* by running::
+*Build Mandyoc* by running:
+
+.. code-block::
 
 	make all
+
+Next, *install Mandyoc* in `~/.local/bin` with:
+
+.. code-block::
+
+	make install
 
 .. note::
 


### PR DESCRIPTION
In the Makefile and installation instruction, I removed the  default  path to $HOME/petsc. 

- Remove the default path for pests at ~
- Add instruction to  add a symlinks of mpirun
- Add instruction to create an env variable for PETSC_DIR before build Mandyoc  