### PR TITLE
Add docker images

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,64 @@
+name: publish-image
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@148d9a848c6acaf90a3ec30bc5062f646f8a4163
+        with:
+          access_token: ${{ github.token }}
+
+      # Cache layer
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      # Checkout your repository under $GITHUB_WORKSPACE
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ggciag/mandyoc
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=semver,pattern={{raw}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./docker/mandyoc/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-mandyoc
+/mandyoc
 test/__pycache__/
 
 # Ignore the documentation building folder

--- a/docker/dependencies/Dockerfile
+++ b/docker/dependencies/Dockerfile
@@ -1,0 +1,118 @@
+# =============================================================================
+# MANDYOC Dependencies Docker Image
+# =============================================================================
+#
+# Builds the base Docker image with dependencies for MANDYOC.
+# MANDYOC is hosted at https://github.com/ggciag/mandyoc.
+#
+
+FROM ubuntu:20.04 AS initial_stage
+
+LABEL maintainer "Rafael Silva <rafael.m.silva@alumni.usp.br>"
+
+# =============================================================================
+# Install dependencies
+# =============================================================================
+USER root
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        gcc \
+        gfortran \
+        python3 \
+        python3-dev \
+        python3-distutils \
+        python3-pip \
+        python3-setuptools \
+        vim \
+        nano \
+        git \
+        curl \
+        rsync \
+        ca-certificates \
+        bash-completion \
+        openssh-client \
+        openssh-server && \
+    apt-get clean && \
+    apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    update-ca-certificates
+
+# =============================================================================
+# Add user and set up variables
+# =============================================================================
+FROM initial_stage AS user_stage
+
+ARG USER=aipim
+ARG PETSC_VERSION=3.15.5
+
+ENV USER ${USER}
+ENV HOME /home/${USER}
+ENV PETSC_VERSION ${PETSC_VERSION}
+
+RUN adduser --disabled-password --gecos '' ${USER}
+RUN adduser ${USER} sudo; echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+RUN chown -R ${USER}:${USER} ${HOME}
+
+USER ${USER}
+
+# =============================================================================
+# Building and installing PETSc
+# =============================================================================
+FROM user_stage AS petsc_stage
+
+RUN mkdir -p ${HOME}/petsc-${PETSC_VERSION} && \
+    mkdir -p $(dirname ${HOME}/tmp/petsc-pkg) && \
+    curl -k https://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-${PETSC_VERSION}.tar.gz \
+        | tar xzvf - -C $(dirname ${HOME}/tmp/petsc-${PETSC_VERSION}) && \
+    cd ${HOME}/tmp/petsc-${PETSC_VERSION} && \
+    python3 ./configure \
+        --prefix=${HOME}/petsc-${PETSC_VERSION} \
+        --with-debugging=0 \
+        --with-cc=gcc \
+        --with-cxx=g++ \
+        --with-fc=gfortran \
+        --download-fblaslapack \
+        --download-mpich \
+        --download-superlu_dist \
+        --download-metis \
+        --download-parmetis \
+        --download-mumps \
+        --download-scalapack && \
+    make && \
+    make install
+
+# =============================================================================
+# Install python requirements (for running examples and tests)
+# =============================================================================
+FROM petsc_stage AS python_stage
+
+COPY ./env/requirements.txt ${HOME}/tmp/requirements.txt
+
+RUN pip3 install -r ${HOME}/tmp/requirements.txt
+
+# =============================================================================
+# Clean up
+# =============================================================================
+FROM python_stage AS cleanup_stage
+
+RUN rm -rf ${HOME}/tmp
+
+# =============================================================================
+# Final setup
+# =============================================================================
+FROM cleanup_stage AS base_stage
+
+RUN chown -R ${USER}:${USER} ${HOME}
+
+ENV PETSC_DIR ${HOME}/petsc-${PETSC_VERSION}
+ENV MPIEXEC ${PETSC_DIR}/bin/mpiexec
+ENV PATH="${PETSC_DIR}/bin:${PATH}"
+
+USER ${USER}
+
+WORKDIR ${HOME}

--- a/docker/mandyoc/Dockerfile
+++ b/docker/mandyoc/Dockerfile
@@ -1,0 +1,47 @@
+# =============================================================================
+# MANDYOC Docker Image
+# =============================================================================
+#
+# Builds a Docker image for geodynamics modelling software MANDYOC.
+# MANDYOC is hosted at https://github.com/ggciag/mandyoc.
+#
+
+FROM ggciag/mandyoc-dependencies:latest as mandyoc_stage
+
+LABEL maintainer "Rafael Silva <rafael.m.silva@alumni.usp.br>"
+
+# =============================================================================
+# Initialize
+# =============================================================================
+# ARG USER=aipim
+# ARG PETSC_VERSION=3.15.5
+
+# ENV USER ${USER}
+# ENV HOME /home/${USER}
+# ENV PETSC_VERSION ${PETSC_VERSION}
+# ENV PETSC_DIR ${HOME}/petsc-${PETSC_VERSION}
+# ENV MPIEXEC ${PETSC_DIR}/bin/mpiexec
+
+ENV MANDYOC_DIR ${HOME}/mandyoc
+
+# =============================================================================
+# Build MANDYOC
+# =============================================================================
+COPY --chown=${USER}:${USER} . ${MANDYOC_DIR}
+
+RUN mkdir -p ${HOME}/.local/bin && \
+    cd ${MANDYOC_DIR} && \
+    make clear && \
+    make install
+
+# =============================================================================
+# Final setup
+# =============================================================================
+FROM mandyoc_stage
+
+ENV PATH="${HOME}/.local/bin:${PATH}"
+ENV MANDYOC ${HOME}/.local/bin/mandyoc
+
+USER ${USER}
+
+WORKDIR ${HOME}

--- a/env/requirements.txt
+++ b/env/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+matplotlib
+pandas
+pytest


### PR DESCRIPTION
Add a docker image for a base environment (dependencies) and an image with mandyoc installed.

This will need to be merged after PR #55, so some changes might be needed due Makefile changes.

Some working on tests will be needed as well, so we can use this image to run automated tests.

Fixes #24 (and take over #29).

Partially addresses #53.

Base (dependencies) images: https://hub.docker.com/r/ggciag/mandyoc-dependencies

- [X] setup dockerhub-github (token)
- [X] setup workflow to build image for releases