### PR TITLE
fix broken makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ SOURCEC = $(SRC)/main.cpp \
 	$(SRC)/sp.cpp
 OBJECTS = $(SOURCEC:%.cpp=%.o)
 PREFIX = $(HOME)/.local
-BINDIR = $(PREFIX)/bin
-INSTALL_PATH = bin
+INSTALL_PATH = $(PREFIX)/bin
+BUILDDIR = bin
 MANDYOC = $(BUILDDIR)/mandyoc
 
 


### PR DESCRIPTION
Fix #59 

This reverts naming and fix variable name used to build the executable inside the new `bin` folder.