### PR TITLE
fix cross reference error

### DIFF
--- a/docs/files/benchmarks.rst
+++ b/docs/files/benchmarks.rst
@@ -65,7 +65,7 @@ For the *case 1a* where :math:`\eta_0/\eta_r=1.00`, :numref:`vankekenCase1aEvolu
   :width: 80%
   :alt: Results
 
-Evolution of the isoviscous Rayleigh-Taylor instability for :math:`\eta_0/\eta_r=1.00`. The best result presented by van Keken et al. (1997) :cite:`vankeken1997` are on the left and the *Mandyoc* results are on the right.
+  Evolution of the isoviscous Rayleigh-Taylor instability for :math:`\eta_0/\eta_r=1.00`. The best result presented by van Keken et al. (1997) :cite:`vankeken1997` are on the left and the *Mandyoc* results are on the right.
 
 .. note::
   Because of the different methods used by van Keken et al. (1997) :cite:`vankeken1997` and *Mandyoc*, the *Mandyoc* results for the evolution of the isoviscous Rayleigh-Taylor instability presents its data colored instead of contoured.


### PR DESCRIPTION
Some missing white space in figure legend was causing a cross reference error and hence not numbering figures correctly.

This just add missing space to fix this cross reference error.