### PR TITLE
Changes to the "How to install" section of the docs

### DIFF
--- a/docs/files/installation.rst
+++ b/docs/files/installation.rst
@@ -126,6 +126,12 @@ Finally, add a symlink of `mpirun` to `~/.local/bin`:
 
 	ln -s /path/to/petsc/arch-label-optimized/bin/mpirun ~/.local/bin/mpirun
 
+.. note::
+
+    Make sure the directory ``~/.local/bin`` exists, otherwise the above
+    command will fail.
+	You can create it by running ``mkdir -p ~/.local/bin``.
+
 
 *Mandyoc* Installation
 ----------------------

--- a/docs/files/installation.rst
+++ b/docs/files/installation.rst
@@ -55,6 +55,10 @@ Check out the `PETSc installation`_ for details.
 	The following steps its a example installation with minimum requirements
 	to run *Mandyoc*.
 
+**Requirements:**
+
+* ``CMake``
+
 The first step is to **download** PETSc (v3.15.5) release from `PETSc website`_
 or **clone** the repository into your machine.
 *Mandyoc* might work with latest release of PETSc, but this is not guaranteed

--- a/docs/files/installation.rst
+++ b/docs/files/installation.rst
@@ -142,6 +142,7 @@ To clone the repository, navigate to the directory you wish to install *Mandyoc*
 .. code-block:: bash
 
    git clone https://github.com/ggciag/mandyoc
+   cd mandyoc
 
 Before to install Mandyoc, you mast *set an environment variable* which indicates the path to PETSc installation folder:
 

--- a/docs/files/installation.rst
+++ b/docs/files/installation.rst
@@ -37,6 +37,7 @@ With required python packages:
 To run the tests, some additional python packages are required:
 
 * pytest
+* numpy
 
 To build the documentation, further python packages are necessary:
 

--- a/docs/files/installation.rst
+++ b/docs/files/installation.rst
@@ -58,7 +58,7 @@ Check out the `PETSc installation`_ for details.
 The first step is to **download** PETSc (v3.15.5) release from `PETSc website`_
 or **clone** the repository into your machine.
 *Mandyoc* might work with latest release of PETSc, but this is not guaranteed
-since new verions might introduce breaking changes.
+since new versions might introduce breaking changes.
 
 Clone the repository to your desired location::
 

--- a/docs/files/installation.rst
+++ b/docs/files/installation.rst
@@ -124,7 +124,7 @@ Finally, add a symlink of `mpirun` to `~/.local/bin`:
 
 .. code-block::
 
-	ln -s /path/to/pets/arch-label-optimized/bin/mpirun ~/.local/bin/mpirun
+	ln -s /path/to/petsc/arch-label-optimized/bin/mpirun ~/.local/bin/mpirun
 
 
 *Mandyoc* Installation


### PR DESCRIPTION
Add numpy as requirement for running the tests. Add a `cd mandyoc` line after
cloning the repo. Add a note instructing to create `~/.local/bin` before creating
the `mpirun` symbolic link. Fix typo in "petsc". Add requirements for building
PETSc. Fix typo in "versions".

I've made a few changes to the "How to install" section of the docs after installing PETSc and Mandyoc following it.
Most of the changes are based on that experience. Feel free to edit them, they are just proposals!

Thanks for hard work of maintaining and documenting Mandyoc!
