### PR TITLE
Fix strain seed command

### DIFF
--- a/src/DMSwarm_2d.cpp
+++ b/src/DMSwarm_2d.cpp
@@ -62,7 +62,7 @@ extern PetscInt print_step_files;
 extern PetscInt *seed_layer;
 extern PetscInt seed_layer_size;
 extern PetscBool seed_layer_set;
-
+extern PetscBool strain_seed_constant;
 
 extern PetscReal *strain_seed_layer;
 extern PetscInt strain_seed_layer_size;
@@ -447,12 +447,20 @@ PetscErrorCode createSwarm_2d()
 
 				if (seed_layer_set == PETSC_TRUE) {
 					if (seed_layer_size == 1 && layer_array[p] == seed_layer[0]) {
-						strain_array[p] = strain_seed_layer[0];
+						if (strain_seed_constant == PETSC_TRUE) {
+							strain_array[p] = strain_seed_layer[0];
+						} else {
+							strain_array[p] += strain_seed_layer[0];
+						}
 					}
 					else {
 						for (int k = 0; k < seed_layer_size; k++) {
 							if (layer_array[p] == seed_layer[k]) {
-								strain_array[p] = strain_seed_layer[k];
+								if (strain_seed_constant == PETSC_TRUE) {
+									strain_array[p] = strain_seed_layer[k];
+								} else {
+									strain_array[p] += strain_seed_layer[k];
+								}
 							}
 						}
 					}

--- a/src/DMSwarm_3d.cpp
+++ b/src/DMSwarm_3d.cpp
@@ -74,6 +74,7 @@ extern PetscBool seed_layer_set;
 extern PetscReal *strain_seed_layer;
 extern PetscInt strain_seed_layer_size;
 extern PetscBool strain_seed_layer_set;
+extern PetscBool strain_seed_constant;
 
 extern PetscReal epsilon_x;
 
@@ -479,12 +480,20 @@ PetscErrorCode createSwarm_3d()
 
 				if (seed_layer_set == PETSC_TRUE) {
 					if (seed_layer_size == 1 && layer_array[p] == seed_layer[0]) {
-						strain_array[p] = strain_seed_layer[0];
+						if (strain_seed_constant == PETSC_TRUE) {
+							strain_array[p] = strain_seed_layer[0];
+						} else {
+							strain_array[p] += strain_seed_layer[0];
+						}
 					}
 					else {
 						for (int k = 0; k < seed_layer_size; k++) {
 							if (layer_array[p] == seed_layer[k]) {
-								strain_array[p] = strain_seed_layer[k];
+								if (strain_seed_constant == PETSC_TRUE) {
+									strain_array[p] = strain_seed_layer[k];
+								} else {
+									strain_array[p] += strain_seed_layer[k];
+								}
 							}
 						}
 					}

--- a/src/header.h
+++ b/src/header.h
@@ -323,6 +323,9 @@ PetscReal *strain_seed_layer;
 PetscInt strain_seed_layer_size;
 PetscBool strain_seed_layer_set = PETSC_FALSE;
 
+PetscBool strain_seed_constant = PETSC_TRUE;
+PetscBool strain_seed_constant_set = PETSC_FALSE;
+
 PetscScalar *var_bcv_time;
 PetscScalar *var_bcv_scale;
 PetscInt n_var_bcv=0;
@@ -364,8 +367,8 @@ PetscInt n_var_climate;
 PetscInt cont_var_climate=0;
 
 
-//Rescaled variables for non-dimensional scenarios 
-//(necessary to calculate the effective viscosity using 
+//Rescaled variables for non-dimensional scenarios
+//(necessary to calculate the effective viscosity using
 //dimensional pressure, temperature, strain rate and cummulative strain)
 PetscInt non_dim = 0;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@ static char help[] = "\n\nMANDYOC: MANtle DYnamics simulatOr Code\n\n"\
 "   -seed [int]:          specify one (or more, comma separated) layer for weak plastic criterium (seed layer)\n"\
 "                         default value: no layer specified\n\n"\
 "   -strain_seed [float]: specify one (or more, comma separated) value for the seed layer strain\n"\
-"                         default value: 2.0\n\n"\
+"                         default value: 0.5\n\n"\
 "";
 
 /* MANDYOC: MANtle DYnamics simulatOr Code*/
@@ -232,7 +232,7 @@ int main(int argc,char **args)
 		else{
 			PetscPrintf(PETSC_COMM_WORLD,"\n\nstep = %d, time = %.3g yr, dt = %.3g yr\n",tcont,tempo,dt_calor);
 		}
-		
+
 
 		//PetscPrintf(PETSC_COMM_WORLD,"next sp %.3g Myr\n\n", sp_eval_time);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,12 @@
 static char help[] = "\n\nMANDYOC: MANtle DYnamics simulatOr Code\n\n"\
 "Flags:\n\n"\
-"   -seed [int]:          specify one (or more, comma separated) layer for weak plastic criterium (seed layer)\n"\
-"                         default value: no layer specified\n\n"\
-"   -strain_seed [float]: specify one (or more, comma separated) value for the seed layer strain\n"\
-"                         default value: 0.5\n\n"\
+"   -seed [int]:                  specify one (or more, comma separated) layer for weak plastic criterium (seed layer)\n"\
+"                                 default value: no layer specified\n\n"\
+"   -strain_seed [float]:         specify one (or more, comma separated) value for the seed layer strain\n"\
+"                                 default value: 0.5\n\n"\
+"   -strain_seed_constant [bool]: specify if the strain_seed value is used as a constant value (default)\n"\
+"                                 or if it is summed over the random initial strain\n"\
+"                                 default value: true\n\n"\
 "";
 
 /* MANDYOC: MANtle DYnamics simulatOr Code*/

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -11,6 +11,8 @@ extern PetscBool seed_layer_set;
 extern PetscReal *strain_seed_layer;
 extern PetscInt strain_seed_layer_size;
 extern PetscBool strain_seed_layer_set;
+extern PetscBool strain_seed_constant;
+extern PetscBool strain_seed_constant_set;
 extern double h_air;;
 extern PetscInt pressure_in_rheol;
 extern PetscBool sp_surface_processes;
@@ -34,11 +36,11 @@ PetscErrorCode parse_options(int rank)
 
 	if (n_interfaces > 0 && interfaces_from_ascii == 1) {
 		ierr = PetscCalloc1(n_interfaces, &seed_layer); CHKERRQ(ierr);
-		seed_layer_size = n_interfaces;
+		seed_layer_size = n_interfaces + 1;
 		ierr = PetscOptionsGetIntArray(NULL, NULL, "-seed", seed_layer, &seed_layer_size, &seed_layer_set); CHKERRQ(ierr);
 
 		ierr = PetscCalloc1(n_interfaces, &strain_seed_layer); CHKERRQ(ierr);
-		strain_seed_layer_size = n_interfaces;
+		strain_seed_layer_size = n_interfaces + 1;
 		ierr = PetscOptionsGetRealArray(NULL, NULL, "-strain_seed", strain_seed_layer, &strain_seed_layer_size, &strain_seed_layer_set); CHKERRQ(ierr);
 		if (strain_seed_layer_set == PETSC_TRUE && seed_layer_set == PETSC_FALSE) {
 			PetscPrintf(PETSC_COMM_WORLD, "Specify the seed layer with the flag -seed (required by -strain_seed)\n");
@@ -59,6 +61,12 @@ PetscErrorCode parse_options(int rank)
 			PetscPrintf(PETSC_COMM_WORLD, "seed layer: %d - strain: %lf\n", seed_layer[k], strain_seed_layer[k]);
 		}
 		PetscPrintf(PETSC_COMM_WORLD, "\n");
+
+		ierr = PetscOptionsGetBool(NULL, NULL, "-strain_seed_constant", &strain_seed_constant, &strain_seed_constant_set); CHKERRQ(ierr);
+		if (strain_seed_constant_set == PETSC_TRUE && seed_layer_set == PETSC_FALSE) {
+			PetscPrintf(PETSC_COMM_WORLD, "Specify the seed layer with the flags -seed and -strain_seed (required by -strain_seed_constant)\n");
+			exit(1);
+		}
 	}
 
 	h_air = -1.0;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -49,9 +49,9 @@ PetscErrorCode parse_options(int rank)
 			exit(1);
 		}
 		if (strain_seed_layer_set == PETSC_FALSE && seed_layer_set == PETSC_TRUE) {
-			PetscPrintf(PETSC_COMM_WORLD, "Using default value '2.0' for -strain_seed (for all seed layers)\n");
+			PetscPrintf(PETSC_COMM_WORLD, "Using default value '0.5' for -strain_seed (for all seed layers)\n");
 			for (int k = 0; k < seed_layer_size; k++) {
-				strain_seed_layer[k] = 2.0;
+				strain_seed_layer[k] = 0.5;
 			}
 		}
 		PetscPrintf(PETSC_COMM_WORLD, "Number of seed layers: %d\n", seed_layer_size);


### PR DESCRIPTION
Fixes #97

Additionally, a new command is available: `-strain_seed_constant`.
This command expects a logical (true or false) value.
It defaults to `true` to keep the code compatible to previous versions.

If `false` is specified, then the values passed via `-strain_seed` command are summed over to the `random_initial_strain` value. Otherwise, the values are used as constant values.