### PR TITLE
add missing command to build mandyoc

### DIFF
--- a/docker/mandyoc/Dockerfile
+++ b/docker/mandyoc/Dockerfile
@@ -32,6 +32,7 @@ COPY --chown=${USER}:${USER} . ${MANDYOC_DIR}
 RUN mkdir -p ${HOME}/.local/bin && \
     cd ${MANDYOC_DIR} && \
     make clear && \
+    make all && \
     make install
 
 # =============================================================================


### PR DESCRIPTION
Fixes #107 

This PR just add the `make all` call in the chain of commands to build Mandyoc, in the Dockerfile.