### PR TITLE
Fix comparision of number of layer from -seed command and interfaces file

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,7 +102,7 @@ int main(int argc,char **args)
 	reader(rank, "param.txt");
 
 	// Check if the number of interfaces in "param.txt" is higher than then number read from command line
-	if (seed_layer_set && seed_layer_size > n_interfaces) {
+	if (seed_layer_set && seed_layer_size > (n_interfaces + 1)) {
 		PetscPrintf(PETSC_COMM_WORLD, "Error: The number of layers specified in command line \"-seed\" command is higher than the number in \"param.txt\".\n");
 	}
 


### PR DESCRIPTION
This fix the comparison of the number of layers parsed with the `-seed` command and the number of layers in the `interfaces.txt` file.