### PR TITLE
fix problem caused by race conditions when generating random numbers

### DIFF
--- a/src/DMSwarm_move.cpp
+++ b/src/DMSwarm_move.cpp
@@ -80,6 +80,9 @@ extern PetscInt periodic_boundary;
 
 extern PetscReal epsilon_x;
 
+extern double tempo;
+extern int tcont;
+
 PetscReal linear_interpolation(PetscReal rx, PetscReal rz,PetscScalar V0, PetscScalar V1, PetscScalar V2, PetscScalar V3){
 	PetscReal rfac,vx;
 	rfac = (1.0-rx)*(1.0-rz);
@@ -579,7 +582,7 @@ PetscErrorCode moveSwarm(int dimensions, PetscReal dt)
 										inter_A[layer_array[p]], inter_n[layer_array[p]], inter_Q[layer_array[p]], inter_V[layer_array[p]], layer_array[p]);
 
 			// PetscPrintf(PETSC_COMM_WORLD, "p: %d, strain: %E\n", p, strain_fac[p]);
-			
+
 			array[3*p  ] += dt * vx;
 			array[3*p+1] += dt * vy;
 			array[3*p+2] += dt * vz;
@@ -614,6 +617,9 @@ PetscErrorCode moveSwarm(int dimensions, PetscReal dt)
 PetscErrorCode Swarm_add_remove_2d()
 {
 	PetscErrorCode ierr=0;
+
+	PetscMPIInt rank;
+	ierr = MPI_Comm_rank(PETSC_COMM_WORLD, &rank); CHKERRQ(ierr);
 
 	PetscInt *carray;
 
@@ -779,9 +785,15 @@ PetscErrorCode Swarm_add_remove_2d()
 						cont_p++;
 					}
 				}
+				unsigned long long tmp =
+					(unsigned long long)rank * 16557697ULL
+					+ (unsigned long long)tcont * 1234577ULL
+					+ (unsigned long long)k * (unsigned long long)Nx
+					+ (unsigned long long)i;
+				unsigned int cell_seed = (unsigned int)tmp;
 				for (pp=0;pp<10;pp++){
-					rx = 2.0*(float)rand_r(&seed)/RAND_MAX-1.0;
-					rz = 2.0*(float)rand_r(&seed)/RAND_MAX-1.0;
+					rz = 2.0*(float)rand_r(&cell_seed)/(float)RAND_MAX-1.0;
+					rz = 2.0*(float)rand_r(&cell_seed)/(float)RAND_MAX-1.0;
 
 					cx_v[pp] = i*dx_const + (0.5*rx+0.5)*dx_const;
 					cz_v[pp] = k*dz_const - depth + (0.5*rz+0.5)*dz_const;
@@ -798,9 +810,11 @@ PetscErrorCode Swarm_add_remove_2d()
 						dx = cx - array[ppp[p]*2];
 						dz = cz - array[ppp[p]*2+1];
 
-						if (dx*dx+dz*dz<dist_p){
+						PetscReal d2 = dx*dx + dz*dz + 1e-12 * (pp + p*10.0);
+
+						if (d2 < dist_p){
 							p_prox = ppp[p];
-							dist_p = dx*dx+dz*dz;
+							dist_p = d2;
 						}
 					}
 					if (dist<dist_p){

--- a/src/DMSwarm_move.cpp
+++ b/src/DMSwarm_move.cpp
@@ -792,7 +792,7 @@ PetscErrorCode Swarm_add_remove_2d()
 					+ (unsigned long long)i;
 				unsigned int cell_seed = (unsigned int)tmp;
 				for (pp=0;pp<10;pp++){
-					rz = 2.0*(float)rand_r(&cell_seed)/(float)RAND_MAX-1.0;
+					rx = 2.0*(float)rand_r(&cell_seed)/(float)RAND_MAX-1.0;
 					rz = 2.0*(float)rand_r(&cell_seed)/(float)RAND_MAX-1.0;
 
 					cx_v[pp] = i*dx_const + (0.5*rx+0.5)*dx_const;


### PR DESCRIPTION
This fixes #127.

The seed used for generation the random number was modified to be cell based evaluated in 64 bits then truncated.
Also, it was added a tie-breaker when comparing distances to avoid any errors due comparisons of very close float values.