### PR TITLE
add missing ;

### DIFF
--- a/src/sp.cpp
+++ b/src/sp.cpp
@@ -451,7 +451,7 @@ PetscErrorCode sp_evaluate_surface_processes_2d_diffusion(PetscReal dt)
     PetscInt si;
     PetscInt nlocal;
     PetscReal *array;
-    PetscInt n
+    PetscInt n;
 
     PetscFunctionBeginUser;
 


### PR DESCRIPTION
Fix typo: add missing `;` to variable declaration.