### PR TITLE
Export the lithology of all particles

### DIFF
--- a/src/header.h
+++ b/src/header.h
@@ -381,6 +381,8 @@ PetscReal air_threshold_density;
 
 PetscBool export_kappa = PETSC_FALSE;
 
+PetscBool export_lithology = PETSC_FALSE;
+
 // surface processes
 DM dmcell_s;
 DM dms_s;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,7 @@ PetscErrorCode Swarm_add_remove_2d();
 PetscErrorCode Swarm_add_remove_3d();
 PetscErrorCode SwarmViewGP_2d(DM dms,const char prefix[]);
 PetscErrorCode SwarmViewGP_3d(DM dms,const char prefix[]);
+PetscErrorCode ViewLithology_2d(DM dms,const char prefix[]);
 PetscErrorCode Init_Veloc(int dimensions);
 PetscErrorCode reader(int rank, const char fName[]);
 PetscErrorCode write_veloc(int cont, PetscInt binary_out);
@@ -64,6 +65,7 @@ int main(int argc,char **args)
 {
 	PetscErrorCode ierr;
 	char prefix[PETSC_MAX_PATH_LEN];
+	char prefix_litho[PETSC_MAX_PATH_LEN];
 
 	PetscFunctionBeginUser;
 
@@ -319,12 +321,18 @@ int main(int argc,char **args)
 			ierr = write_pressure(tcont,binary_output);
 			ierr = write_tempo(tcont);
 			PetscSNPrintf(prefix,PETSC_MAX_PATH_LEN-1,"step_%d",tcont);
+			PetscSNPrintf(prefix_litho,PETSC_MAX_PATH_LEN-1,"litho_%d",tcont);
 			if (geoq_on){
 				if (print_step_files==1){
 					if (dimensions == 2) {
 						ierr = SwarmViewGP_2d(dms,prefix);CHKERRQ(ierr);
 					} else {
 						ierr = SwarmViewGP_3d(dms,prefix);CHKERRQ(ierr);
+					}
+				}
+				if (export_lithology==PETSC_TRUE){ //!!! Must be implemented for 3D version
+					if (dimensions == 2) {
+						ierr = ViewLithology_2d(dms,prefix_litho);CHKERRQ(ierr);
 					}
 				}
 

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -102,6 +102,7 @@ extern PetscInt high_kappa_in_asthenosphere;
 extern PetscBool plot_sediment;
 extern PetscBool a2l;
 extern PetscBool export_kappa;
+extern PetscBool export_lithology;
 
 // Removed from parameter file
 extern double H_lito;
@@ -302,6 +303,8 @@ PetscErrorCode reader(int rank, const char fName[]){
 			else if (strcmp(tkn_w, "a2l") == 0) {a2l = check_a_b_bool(tkn_w, tkn_v, "True", "False");}
 			else if (strcmp(tkn_w, "export_thermal_diffusivity") == 0) {export_kappa = check_a_b_bool(tkn_w, tkn_v, "True", "False");}
 
+			else if (strcmp(tkn_w, "export_lithology") == 0) {export_lithology = check_a_b_bool(tkn_w, tkn_v, "True", "False");}
+
 			else if (strcmp(tkn_w, "high_kappa_in_asthenosphere") == 0) {high_kappa_in_asthenosphere = check_a_b(tkn_w, tkn_v, "True", "False");}
 
 			else if (strcmp(tkn_w, "nondimensionalization") == 0) {non_dim = check_a_b(tkn_w, tkn_v, "True", "False");}
@@ -387,6 +390,7 @@ PetscErrorCode reader(int rank, const char fName[]){
 	MPI_Bcast(&timeMAX,1,MPI_DOUBLE,0,PETSC_COMM_WORLD);
 	MPI_Bcast(&dt_MAX,1,MPI_DOUBLE,0,PETSC_COMM_WORLD);
 	MPI_Bcast(&print_step,1,MPI_LONG,0,PETSC_COMM_WORLD);
+
 	MPI_Bcast(&visco_r,1,MPI_DOUBLE,0,PETSC_COMM_WORLD);
 	MPI_Bcast(&visc_MAX,1,MPI_DOUBLE,0,PETSC_COMM_WORLD);
 	MPI_Bcast(&visc_MIN,1,MPI_DOUBLE,0,PETSC_COMM_WORLD);
@@ -474,6 +478,8 @@ PetscErrorCode reader(int rank, const char fName[]){
 	MPI_Bcast(&weakening_min,1,MPIU_REAL,0,PETSC_COMM_WORLD);
 	MPI_Bcast(&weakening_max,1,MPIU_REAL,0,PETSC_COMM_WORLD);
 	MPI_Bcast(&export_kappa,1,MPI_C_BOOL,0,PETSC_COMM_WORLD);
+
+	MPI_Bcast(&export_lithology,1,MPI_C_BOOL,0,PETSC_COMM_WORLD);
 
 	MPI_Bcast(&non_dim,1,MPI_INT,0,PETSC_COMM_WORLD);
 


### PR DESCRIPTION
This PR add a function to export the lithology of all particles assuming that each 2D finite element is subdivided by 5x5 cells.
The index of each cell is indicated in the first two columns of the file.
The third column is the lithologic index.